### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/WebApplication1/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/WebApplication1/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.escapeCssMeta(element) ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/DraghiciRadu/TennisTrackerSE/security/code-scanning/5](https://github.com/DraghiciRadu/TennisTrackerSE/security/code-scanning/5)

To fix the problem, we need to ensure that any user-controlled input used in jQuery selectors is properly sanitized to prevent XSS attacks. The best way to fix this issue is to use the `escapeCssMeta` function to sanitize the `element` variable before it is used in the jQuery selector on line 1086. This will ensure that any special characters in the input are escaped, preventing the input from being interpreted as HTML or script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
